### PR TITLE
First prototype [Work In Progress]

### DIFF
--- a/Source/SLLibMacros.h
+++ b/Source/SLLibMacros.h
@@ -1,0 +1,13 @@
+//
+//  SLLibMacros.h
+//  LoggingDemo
+//
+//  Created by 利辺羅 on 2014/12/10.
+//  Copyright (c) 2014年 SLF4C. All rights reserved.
+//
+
+#import "SLMacros.h"
+
+#undef  SLMarkerName
+#define SLMarkerName @"Other"
+

--- a/Source/SLLogger.h
+++ b/Source/SLLogger.h
@@ -1,0 +1,76 @@
+//
+//  SLLogger.h
+//  LoggingDemo
+//
+//  Created by 利辺羅 on 2014/12/09.
+//  Copyright (c) 2014年 SLF4C. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol SLLogger, SLMarker;
+
+typedef NS_ENUM(NSUInteger, SLLevel)
+{
+    SLLevelOff = 0,
+    SLLevelVerbose,
+    SLLevelDebug,
+    SLLevelInfo,
+    SLLevelWarning,
+    SLLevelError
+};
+
+
+@interface SLLog : NSObject
+
++ (Class<SLLogger>)loggerClass;
++ (void)setLoggerClass:(Class<SLLogger>)loggerClass;
+
++ (id<SLMarker>)appMarker;
++ (NSArray *)allMarkers;
++ (id<SLMarker>)markerWithName:(NSString *)name;
+
+@end
+
+
+@protocol SLLogger <NSObject>
+
++ (Class<SLMarker>)markerClass;
+
++ (void)logWithMarker:(id<SLMarker>)marker
+                level:(SLLevel)level
+                 path:(const char *)file
+                 line:(uint32_t)line
+             function:(const char *)function
+               format:(NSString *)format, ... NS_FORMAT_FUNCTION(6, 7);
+
++ (BOOL)isLogWithMarker:(id<SLMarker>)marker
+        enabledForLevel:(SLLevel)level;
+
+@end
+
+
+@protocol SLMarker <NSObject>
+
+@property (nonatomic, strong) NSString * name; // Should be read-only
+
+@end
+
+
+@interface SLSimpleMarker : NSObject <SLMarker>
+
+@property (nonatomic, strong) NSString * name;
+
+@end
+
+
+//@interface SLNOPLogger : NSObject <SLLogger>
+//
+//@end
+//
+//
+//@interface SLNSLogger : NSObject <SLLogger>
+//
+//@end
+//
+//

--- a/Source/SLLogger.m
+++ b/Source/SLLogger.m
@@ -1,0 +1,176 @@
+//
+//  SLLogger.m
+//  LoggingDemo
+//
+//  Created by 利辺羅 on 2014/12/09.
+//  Copyright (c) 2014年 SLF4C. All rights reserved.
+//
+
+#import "SLLogger.h"
+#import "SLLibMacros.h"
+
+@implementation SLLog
+
+static Class<SLLogger> _loggerClass;
+static NSMutableDictionary * _markers;
+
++ (Class<SLLogger>)loggerClass
+{
+//    if (!_loggerClass)
+//    {
+//        #ifdef DEBUG
+//            _loggerClass = [SLNSLogger class];
+//        #else
+//            _loggerClass = [SLNOPLogger class];
+//        #endif
+//    }
+    return _loggerClass;
+}
+
++ (void)setLoggerClass:(Class<SLLogger>)loggerClass
+{
+    _loggerClass = loggerClass;
+    
+    SLInfo(@"Logger set to '%@'.", NSStringFromClass(loggerClass));
+    
+    Class<SLLogger> _lgr = loggerClass;
+    id<SLMarker> _mrk = [self markerWithName:SLMarkerName];
+    SLLevel _lvl = SLLevelInfo;
+    if ([_lgr isLogWithMarker:_mrk
+              enabledForLevel:_lvl])
+    {
+        [_lgr logWithMarker:_mrk
+                      level:_lvl
+                       path:__FILE__
+                       line:__LINE__
+                   function:__PRETTY_FUNCTION__
+                     format:@"Set to log with '%@'.", NSStringFromClass(loggerClass)];
+    }
+}
+
++ (id<SLMarker>)appMarker
+{
+    return [self markerWithName:@"App"];
+}
+
++ (NSArray *)allMarkers
+{
+    NSArray * orderedMarkerNames = [[_markers allKeys]
+                                    sortedArrayWithOptions:0
+                                    usingComparator:^NSComparisonResult(NSString * name1,
+                                                                        NSString * name2)
+                                    {
+                                        if ([name1 isEqualToString:@"App"])
+                                        {
+                                            return NSOrderedAscending;
+                                        }
+                                        if ([name2 isEqualToString:@"App"])
+                                        {
+                                            return NSOrderedDescending;
+                                        }
+                                        return [name1 caseInsensitiveCompare:name2];
+                                    }];
+    NSMutableArray * allMarkers = [NSMutableArray array];
+    for (NSString * name in orderedMarkerNames)
+    {
+        [allMarkers addObject:_markers[name]];
+    }
+    return [NSArray arrayWithArray:allMarkers];
+}
+
++ (id<SLMarker>)markerWithName:(NSString *)name
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^
+                  {
+                      _markers = [NSMutableDictionary dictionary];
+                  });
+    
+    @synchronized (self)
+    {
+        id<SLMarker> marker = _markers[name];
+        if (marker)
+        {
+            return marker;
+        }
+        
+        // New marker
+        Class aClass = [_loggerClass markerClass];
+        marker = [[aClass alloc] init];
+        ((id<SLMarker>)marker).name = name;
+        _markers[name] = marker;
+        
+        return marker;
+    }
+}
+
+@end
+
+
+@implementation SLSimpleMarker
+
+@end
+
+
+//@implementation SLNOPLogger
+//
+//+ (Class<SLMarker>)markerClass
+//{
+//    return nil;
+//}
+//
+//+ (void)logWithMarker:(id<SLMarker>)marker
+//                level:(SLLevel)level
+//                 path:(const char *)file
+//                 line:(uint32_t)line
+//             function:(const char *)function
+//               format:(NSString *)format, ...
+//{
+//    return;
+//}
+//
+//+ (BOOL)isLogWithMarker:(id<SLMarker>)marker
+//        enabledForLevel:(SLLevel)level
+//{
+//    return NO;
+//}
+//
+//@end
+//
+//
+//@implementation SLNSLogger
+//
+//+ (Class<SLMarker>)markerClass
+//{
+//    return [SLSimpleMarker class];
+//}
+//
+//+ (void)logWithMarker:(id<SLMarker>)marker
+//                level:(SLLevel)level
+//                 path:(const char *)file
+//                 line:(uint32_t)line
+//             function:(const char *)function
+//               format:(NSString *)format, ...
+//{
+//    return;
+//}
+//
+//+ (BOOL)isLogWithMarker:(id<SLMarker>)marker
+//        enabledForLevel:(SLLevel)level
+//{
+//    return NO;
+//}
+//
+//+ (SLLevel)logLevelForMarker:(id<SLMarker>)marker
+//{
+//    return SLLevelOff;
+//}
+//
+//+ (void)setLogLevel:(SLLevel)level
+//          forMarker:(id<SLMarker>)marker
+//{
+//    return;
+//}
+//
+//@end
+

--- a/Source/SLMacros.h
+++ b/Source/SLMacros.h
@@ -1,0 +1,29 @@
+//
+//  SLLibMacros.h
+//  LoggingDemo
+//
+//  Created by 利辺羅 on 2014/12/10.
+//  Copyright (c) 2014年 SLF4C. All rights reserved.
+//
+
+#import "SLLogger.h"
+
+#define SLMarkerName @"App"
+
+#define LOG_MACRO(_lvl, _frmt, ...) \
+        do { Class<SLLogger> _lgr = [SLLog loggerClass]; \
+             id<SLMarker> _mrk = [self markerWithName:SLMarkerName]; \
+             if([_lgr isLogWithMarker:_mrk enabledForLevel:_lvl]) { \
+                 [_lgr logWithMarker:_mrk \
+                 level:_lvl \
+                 path:__FILE__ \
+                 line:__LINE__ \
+                 function:__PRETTY_FUNCTION__ \
+                 format:_frmt, ##__VA_ARGS__]; }} while(0)
+
+#define SLError(frmt, ...)   LOG_MACRO(SLLevelError,   frmt, ##__VA_ARGS__)
+#define SLWarning(frmt, ...) LOG_MACRO(SLLevelWarning, frmt, ##__VA_ARGS__)
+#define SLInfo(frmt, ...)    LOG_MACRO(SLLevelInfo,    frmt, ##__VA_ARGS__)
+#define SLDebug(frmt, ...)   LOG_MACRO(SLLevelDebug,   frmt, ##__VA_ARGS__)
+#define SLVerbose(frmt, ...) LOG_MACRO(SLLevelVerbose, frmt, ##__VA_ARGS__)
+


### PR DESCRIPTION
A first try to implement #1:
- A minimal `SLLog` object that keeps track of a `loggerClass` and some common _marker_ logic.
- A `SLLogger` protocol for log framework adapters.
- A `SLMarker` protocol and a `SLSimpleMarker` implementation of that protocol to support context-aware log frameworks.
- Simple `SLMacros` and `SLLibMacros` to be used by Apps and 3rd party libraries respectively.

The façade is "one way" only:
- Wrap log calls to direct them to log frameworks
- ~~Wrap log frameworks configuration/usage.~~
